### PR TITLE
Kgs/won 2023

### DIFF
--- a/decks/10090.txt
+++ b/decks/10090.txt
@@ -3,7 +3,7 @@ Vidor (TX), USA
 May 14th 2022
 3R+F
 15 players
-Norman Brown
+Norm Brown
 https://www.vekn.net/event-calendar/event/10090
 
 -- 3vp in final

--- a/decks/10657.txt
+++ b/decks/10657.txt
@@ -1,0 +1,76 @@
+WoN event 1 - Creation Rites: Newark
+Newark (OH), USA
+June 18h, 2023
+2R+F
+25 players
+winner: Kelly Schultz
+www.vekn.net/event-calendar/event/10657
+
+-- 2GW 7VP, + 3VP in finals
+
+Deck Name: Lord Darby's Tremere
+
+Crypt (12 cards, min=19 max=44 avg=8.08)
+4x Lord Tremere 11 ANI AUS DOM THA VIC obe Tremere:5
+1x Abraham DuSable 8 AUS DOM FOR THA Tremere:6
+1x Ayelech 7 AUS DOM THA prince Tremere:6
+1x Claus Wegener 5 DOM aus for tha Tremere:5
+1x Gerald Windham 9 AUS DOM FOR THA Tremere:5
+1x Karl Schrekt 10 AUS DOM FOR PRE THA 2 votes Tremere:6
+1x Monica Chang 3 dom tha Tremere:5
+1x Sri Sansa 5 DOM aus tha Tremere:6
+1x Trevon Parker 6 AUS DOM THA Tremere:6
+
+Library (90 cards)
+Master (18; 5 trifle)
+2x Academic Hunting Ground
+1x Arcane Library
+3x Blood Doll
+1x Chantry
+1x Coven, The
+1x Direct Intervention
+1x Giant's Blood
+1x Metro Underground
+2x Pentex(TM) Subversion
+1x Powerbase: Montreal
+3x Villein
+1x Wider View
+
+Action (20)
+1x Biothaumaturgic Experiment
+2x Dominate Kine
+5x Govern the Unaligned
+2x Magic of the Smith
+1x Revelations
+4x Rutor's Hand
+5x Scouting Mission
+
+Ally (1)
+1x Carlton Van Wyk
+
+Equipment (3)
+1x Bowl of Convergence
+1x Heart of Nizchetus
+1x Ivory Bow
+
+Action Modifier (19)
+3x Bonding
+2x Command of the Beast
+4x Conditioning
+1x Enkil Cog
+6x Mirror Walk
+3x Seduction
+
+Action Modifier/Reaction (4)
+4x Murmur of the False Will
+
+Reaction (25)
+6x Deflection
+1x Eagle's Sight
+1x Eluding the Arms of Morpheus
+1x Enhanced Senses
+4x Eyes of Argus
+1x My Enemy's Enemy
+7x Obedience
+2x On the Qui Vive
+2x Telepathic Misdirection

--- a/decks/10658.txt
+++ b/decks/10658.txt
@@ -1,0 +1,81 @@
+WoN event 2 - Märzen: Columbus
+Columbus (OH), USA
+June 19th, 2023
+2R+F
+25 players
+Mark Loughman
+www.vekn.net/event-calendar/event/10658
+
+-- 2GW6 + 4vp in the final
+
+Deck Name: Secret Treaties
+Description: Stolen from Vincent and Gines
+
+Crypt (12 cards; Capacity min=7 max=11 avg=9.833333)
+==================
+1x Etrius 11 pro AUS DOM OBF THA Tremere:2
+5x Giotto Verducci 7 for pot pre DAI OBF Baali:2
+1x Gratiano 8 obf pot DOM OBT Lasombra:2
+1x Harrod 11 aus pre ANI CEL OBF POT Nosferatu:2
+1x Leandro 11 cel dom AUS OBF PRE Malkavian:2
+3x Arika 11 aus cel DOM FOR OBF PRE Ventrue:2
+
+Library: 68 cards
+
+Master (14 cards)
+==================
+1x Giant's Blood
+1x Monastery of Shadows
+4x Ashur Tablets
+1x Perfectionist
+1x Powerbase: Montreal
+1x Presence
+3x Villein
+2x Wider View
+
+Action (4 cards)
+==================
+3x Unleash Hell's Fury
+1x Condemnation: Mute
+
+Action Modifier (22 cards)
+==================
+1x Elder Impersonation
+2x Faceless Night
+1x Forgotten Labyrinth
+8x Freak Drive
+2x Into Thin Air
+2x Perfect Paragon
+1x Spying Mission
+3x Voter Captivation
+2x Cloak the Gathering
+
+Action Modifier/Combat (4 cards)
+==================
+4x Swallowed by the Night
+
+Political Action (10 cards)
+==================
+1x Anarchist Uprising
+1x Ancilla Empowerment
+3x Kine Resources Contested
+1x Reckless Agitation
+1x Reins of Power
+3x Banishment
+
+Combat (3 cards)
+==================
+3x Majesty
+
+Ally (1 cards)
+==================
+1x Veneficti
+
+Equipment (6 cards)
+==================
+6x Kaymakli Fragment
+
+Reaction (4 cards)
+==================
+2x Wake with Evening's Freshness
+2x Deflection

--- a/decks/10659.txt
+++ b/decks/10659.txt
@@ -1,0 +1,62 @@
+WoN event 3 - Trophy: Library: Columbus
+Columbus (OH), USA
+June 20, 2023
+2R+F
+20 players
+Kelly Lyons
+www.vekn.net/event-calendar/event/10659
+
+Deck Name: Water Dog - Tiny Dominate
+
+Description: This is an updated version of the same deck that I discussed on my youtube
+channel, READING BETWEEN THE LYONS in the following episodes:
+
+RBTL - VTES - Episode 0025 - Tiny Dominate - Part 1
+RBTL - VTES - Episode 0026 - Tiny Dominate - Part 2
+
+The changes were the addition of DELAYING TACTICS, reducing the amount of MASTER
+CARDS, and replacing SUDDEN REVERSAL with WASH.
+
+https://www.youtube.com/@readingbetweenthelyons
+
+Crypt (14 cards, min=7 max=12 avg=2.57)
+=======================================
+1x Brooke 3 dom tha Tremere antitribu:2
+1x Cameron 3 dom pot Lasombra:2
+1x Diana Vick 3 dom pre Ventrue:3
+1x Ehrich Weiss 3 dom tha Tremere:3
+1x Ember Wright 3 aus dom Tremere antitribu:3
+1x Lana Butcher 3 dom for Ventrue:3
+1x Lia Milliner 3 dom nec Giovanni:3
+1x Saiz 3 aus dom Tremere antitribu:3
+1x Sister Evelyn 3 aus dom Ventrue antitribu:3
+1x Christine Boscacci 2 dom vic Pander:2
+1x Mustafa Rahman 2 dom Tremere:2
+1x Ohanna 2 dom Malkavian:2
+1x Samson 2 dom Ventrue antitribu:2
+1x Royce 1 dom Pander:2
+
+Library (66 cards)
+==================
+Master (15; 6 trifle)
+3x Dominate
+4x Effective Management
+2x Information Highway
+4x Life in the City
+2x Wash
+
+Action (23)
+14x Govern the Unaligned
+9x Scouting Mission
+
+Action Modifier (17)
+10x Foreshadowing Destruction
+3x Seduction
+4x Sleeping Mind, The
+
+Reaction (6)
+3x Deflection
+3x Delaying Tactics
+
+Combat (5)
+5x Absorb the Mind

--- a/decks/10660.txt
+++ b/decks/10660.txt
@@ -1,0 +1,108 @@
+WoN event 4 - Dortmunder: Columbus
+Columbus OH, USA
+June 20th, 2023
+2R+F
+28 players
+Darby Keeney
+www.vekn.net/event-calendar/event/10660
+
+Deck Name: The Shape of Things to Come (MesoAmerican Wing Build)
+Created by: Darby Keeney
+Collaboration/Consultation from: Karl Schaefer
+
+Description: A modification of "Flay the Game" (www.vekn.fr/decks/twd.htm#2019rmdc). This is a proof of concept for a module that many are likely to bolt on to V5 Tzimisce. It also scratches the itch of my obsession with British Museum.
+
+-- 1GW+4, 2VP in finals, win on seeding
+
+Overview: I played most of the first round with an open hand of 9 cards. Having 5-7 stealth and 2-3 combat ends visible at all times was mildly disheartening for the 3 ally-based decks at the table so I didn't bother to remove it.
+
+The second round was less favorable, I barely missed my prey who was tossing 4 point Kindred Spirits in my direction until his prey over-transferred....almost like he didn't consider the possibility of 7 bleed coming his way. I still squeak into the final on a roll-off.
+
+Final Table:
+Jamie: Laz bleed/block (2 VP)
+Matt: Banu Haqium irresponsible bleed
+Paul: D'erlette Nephanus Tablets
+Darby: Xipe BM Manse (2 VP)
+Logan: unnamed Protocol bleed (1 VP)
+
+The Nephandus deck stalled the Banu and Jamie gets back-to-back ousts. He's sitting as 5th seed so it's either engineer his demise or try to blast out 3 VP in a hurry. That first option seemed easier, and if the unnamed misfires, that other option remains viable. But the plan works.
+
+Heads-up with the unnamed was a near thing, compounded by a Weißbier-inspired error on my part. Still managed to barely get the heads-up oust for the 2 VP win on seeding.
+
+Crypt (12 cards, min=23 max=36 avg=7.58)
+5x Xipe Totec 9 ANI AUS PRO VIC archbishop Tzimisce:5
+2x Darvag, The Butcher of Rus 8 ANI VIC aus pot pro Tzimisce:4
+2x Stephen Bateson 6 ani aus tha vic Tzimisce:5
+1x Dr. Morrow, The Skindoctor 5 AUS VIC for Tzimisce:5
+1x Duality 6 AUS VIC ani Tzimisce:4
+1x Ludmijla Rakoczy 7 ANI AUS VIC bishop Tzimisce:5
+
+-- The crypt screws with the meta. Steal allies, burn locations, profit.
+-- Bateson's disciplines blow but standing +1 stealth is too good to pass up.
+
+Library (78 cards)
+Master (24; 7 trifles)
+5x British Museum, London, The
+1x Coven, The
+3x Dreams of the Sphinx
+1x Giant's Blood
+2x Grooming the Protégé -- one of the few decks where this works
+2x Information Highway
+1x Jake Washington
+1x Monastery of Shadows
+1x Pentex(TM) Subversion
+1x Perfectionist - could be a Direct Intervention?
+5x Villein
+1x Wider View
+
+-- The library is 50% to hit a Museum within the first 10 cards and 67% within the first 15 cards, so yes there's math behind these ratios.
+-- It seems like a lot of Masters, but realistically only about 10 non-trifles get played in a normal game. The rest are buried by the Heart or discarded.
+
+Action (8)
+1x Abbot
+2x Deep Song -- could be Fiendish if the Femur gets removed, but the lock effect is good.
+3x Fiendish Tongue
+2x Under Siege -- a little harder to pull off in this build, but still worth duplication.
+
+-- Reduced transient bleed actions are easily offset by 7 copies of Living Manse.
+
+Ally (1)
+1x War Ghoul -- upgrade something randomly stolen.
+
+Equipment (15)
+1x Blood Tears of Kephran
+1x Bowl of Convergence
+2x Cooler -- finances Xipe's special
+1x Femur of Toomler -- Weirding Stone or Sargon Fragment would be better.
+2x Heart of Nizchetus
+7x Living Manse
+1x Palatial Estate
+
+-- Prerange combat ends was instrumental against Laz in Round 1 and the final.
+
+Action Modifier (9)
+4x Changeling
+2x Earth Control
+3x Mind of the Wilds
+
+Action Modifier/Combat (3)
+2x Plasmic Form
+1x Rapid Change
+
+-- Both of these are underplayed stealth/defensive combo cards.
+
+Action Modifier/Reaction (2)
+2x Form of the Bat -- another reason the Femur isn't helpful.
+
+Reaction (11)
+3x Eyes of Argus
+1x My Enemy's Enemy
+2x On the Qui Vive
+5x Telepathic Misdirection
+
+Combat (3)
+3x Form of Mist
+
+Event (2)
+1x NRA PAC -- multiple unlocks with standing combat ends can't be bad.
+1x Scourge of the Enochians -- Aranthebes might be better?

--- a/decks/10661.txt
+++ b/decks/10661.txt
@@ -1,0 +1,114 @@
+WoN event 5 - Elder Library: Columbus
+Columbus (OH), USA
+June 21st, 2023
+2R+F
+22 players
+Karl Schaefer
+www.vekn.net/event-calendar/event/10661
+
+-- 2GW7 + 2.5vp in the final
+
+Deck Name: Hell Rising (Homework 2021)
+Description: unnamed + The Rising
+WoN 2021 Homework Assignment: Darby Keeney, Kelly Schultz, and I discussed how to
+make an unnamed plus The Rising module work. I played this last year at Origins and had
+2 GWs, but a bad final. This year with a slightly tweaked deck, I managed 2 GWs in the
+prelims and another in the finals.
+
+Me: 2.5 VP ->
+Andrew: Tremere toolbox 0 VP ->
+Marshal: Valkyrie bleed 0 VP ->
+Darby: G6 Gangrel wall 0.5 VP ->
+Ben: my Angelique Shamblers + Legionnaire deck 0.5 VP
+
+My opening hand was strong: Enkil Cog, Thirst, The Rising, stealth, and Instantaneous. I
+drew into Mylan, Homunculus, and Blithe Acceptance early. I managed to land my first
+bleed and drop the Enkil Cog only to have Ben DI the Cog! With my own deck! Then, he
+bled me with Trochomancy to remove the possibility that I would recur the Cog into hand
+with Tablets. The game turn real slow for me as Ben managed to get some Shambling
+Hordes and I had to fight with Tremere intercept to get even bleeds of one through (which
+were almost always bounced).
+
+No one drops a second event; The Rising is looking less good in my hand as time moves
+on. I finally get the chance to drop it and another Cog shortly thereafter. After about 75
+minutes of trying to cycle cards, we're back in "go" mode with a fully operational
+unnamed. It takes a bit, but I get a lunge in at around 20 minutes left to get my prey. The
+following turn, I get Marshal. I manage to pop the Tablets and recur my Pentex, Elder
+Impersonation, Psychomachia, and stealth, taking the Pentex to hand. I was hoping to
+bleed Darby on his turn after my next one, as I needed to filter out some useless cards.
+We never got there unfortunately. TBH, the DI of the Cog probably gave me this game by
+making it much slower for me. If I encounter Darby earlier, I probably run into problems
+with the wall.
+
+The Rising played a key role in the final as I prevented several Villeins from hitting the
+table (including two from my prey; they were in hand when I ousted) and removed Darby's
+pool gain engine.
+
+
+Crypt (12 cards, min=11 max=40 avg=6.58)
+6x unnamed, The 10 CEL DAI OBF PRE PRO Baali:6
+1x Melech 4 OBF pro Ministry:6
+1x Skulk 4 OBF ani Nosferatu antitribu:5
+1x Adisa 3 cel obf Banu Haqim:6
+1x Ashley 3 dom obf Malkavian:6
+1x Lubomira Hradok 3 OBF Nosferatu antitribu:5
+1x New Blood 2 san Blood Brother:ANY
+
+Library (66 cards)
+Master (13; 2 trifle)
+4x Ashur Tablets
+1x Coven, The
+1x Direct Intervention
+1x Fortschritt Library
+1x Giant's Blood
+1x Monastery of Shadows
+1x Pentex(TM) Subversion
+1x Perfectionist
+1x Secure Haven
+1x Wider View
+
+Action (8)
+1x Aranthebes, The Immortal
+2x Blithe Acceptance
+1x Contagion
+1x Entrancement
+3x Unleash Hell's Fury
+
+Ally (5)
+1x Carlton Van Wyk
+2x Infernal Servitor
+1x Mylan Horseed
+1x Veneficti
+
+Equipment (5)
+2x Camera Phone
+1x Heart of Nizchetus
+1x Learjet
+1x Signet of King Saul, The
+
+Retainer (2)
+2x Homunculus
+
+Action Modifier (20)
+2x Elder Impersonation
+3x Enkil Cog
+3x Faceless Night
+2x I am Legion
+7x Instantaneous Transformation
+2x Lost in Crowds
+1x Psychomachia
+
+Action Modifier/Combat (2)
+2x Swallowed by the Night
+
+Action Modifier/Reaction (2)
+2x Sense the Sin
+
+Combat (4)
+4x Form of Mist
+
+Event (5)
+1x Break the Code
+1x Nightmares upon Nightmares
+2x Rising, The
+1x Thirst

--- a/decks/10662.txt
+++ b/decks/10662.txt
@@ -1,0 +1,94 @@
+WoN event 6 - Helles Real: Columbus
+Columbus (OH), USA
+June 21, 2023
+2R+F
+28 players
+winner: Guy Russo
+www.vekn.net/event-calendar/event/10662
+
+Deck Name: Obf No Guns
+Author: Guy Russo
+Description:
+
+Crypt (12 cards; Capacity min=2 max=5 avg=3.666667)
+==================
+1x Florentina Lengauer 4 aus OBF Malkavian:4
+1x Frank Litzpar 5 ani for pot OBF Nosferatu antitribu:4
+1x Jackson Asher 2 dom Ventrue:4
+1x Keith Moody 3 DOM Tremere antitribu:4
+1x Lubomira Hradok 3 OBF Nosferatu antitribu:5
+1x Old Neddacka 2 obf Nosferatu antitribu:4
+1x Raphael Catarari 5 aus pot tha OBF PRE Nosferatu antitribu:4
+1x Robin Withers 4 dom obf pre Ventrue:4
+1x Skidmark 5 aus pot FOR OBF Nosferatu antitribu:4
+1x Skulk 4 ani OBF Nosferatu antitribu:5
+1x Black Lotus 5 aus obf ser DOM Follower of Set:4
+1x Dr. Solomon Grey 2 dom pre Caitiff:5
+
+Library: 90 cards
+
+Master (13 cards)
+==================
+1x Information Network
+1x Jake Washington
+1x KRCG News Radio
+1x Archon Investigation
+1x Rumor Mill, Tabloid Newspaper, The
+2x Special Report
+1x Sudden Reversal
+2x Vessel
+1x WMRH Talk Radio
+1x Blood Doll
+1x Direct Intervention
+
+Action (23 cards)
+==================
+10x Inside Dirt
+1x Aranthebes, The Immortal
+2x Night Moves
+10x Computer Hacking
+
+Action Modifier (25 cards)
+==================
+1x Elder Impersonation
+3x Faceless Night
+10x Lost in Crowds
+1x Spying Mission
+3x Veil the Legions
+3x Cloak the Gathering
+3x Conditioning
+1x Domain of Evernight
+
+Action Modifier/Combat (3 cards)
+==================
+3x Swallowed by the Night
+
+Action Modifier/Reaction (1 cards)
+==================
+1x Gift of Sleep
+
+Combat (4 cards)
+==================
+4x Dodge
+
+Ally (3 cards)
+==================
+1x Hellhound
+1x Repo Man
+1x Carlton Van Wyk
+
+Equipment (5 cards)
+==================
+1x Ivory Bow
+4x Leather Jacket
+
+Reaction (12 cards)
+==================
+2x Legwork
+2x On the Qui Vive
+2x Wake with Evening's Freshness
+6x Deflection
+
+Event (1 cards)
+==================
+1x Uncoiling, The

--- a/decks/10730.txt
+++ b/decks/10730.txt
@@ -1,0 +1,66 @@
+Origins - Thursday 1
+Columbus (OH), USA
+June 22nd, 2023
+2R+F
+29 players
+Norman Brown
+www.vekn.net/event-calendar/event/10730
+
+-- 2GW6 + 3vp in the final
+
+Deck Name: Thieves of Magic Glitches
+
+Crypt (16 cards, min=8 max=36 avg=6.25)
+=======================================
+5x Malgorzata 9 AUS DOM THA VIC pre priscus Tremere antitribu:4
+1x Anastasz di Zagreb 8 AUS THA ani cel dom justicar Tremere:3
+1x Ardan Lane 8 AUS THA dom obf pre primogen Tremere:3
+1x Uta Kovacs 8 AUS DOM THA ser Tremere antitribu:4
+1x Carna, The Princess Witch 7 AUS DOM THA primogen Tremere:3
+1x Valerius Maior, Hell's Fool 7 AUS DAI DOM THA nec pre Tremere:4
+1x Valerius Maior, Hell's Fool (ADV) 7 AUS DAI DOM THA nec pre Tremere antitribu:4
+5x Jacob, The Glitch 2 THA Tremere antitribu:3
+
+Library (90 cards)
+==================
+Master (20; 4 trifle)
+7x Dominate
+1x Dreams of the Sphinx
+4x Effective Management
+3x Golconda: Inner Peace
+1x Information Highway
+4x Villein
+
+Action (13)
+11x Govern the Unaligned
+1x Rutor's Hand
+1x Under Siege
+
+Equipment (2)
+1x Bowl of Convergence
+1x Ivory Bow
+
+Political Action (3)
+1x Anarchist Uprising
+1x Ancilla Empowerment
+1x Banishment
+
+Action Modifier (8)
+4x Change of Target
+4x Mirror Walk
+
+Action Modifier/Reaction (7)
+7x Murmur of the False Will
+
+Reaction (9)
+7x Deflection
+2x On the Qui Vive
+
+Combat (27)
+6x Apportation
+5x Flames of the Netherworld
+6x Movement of the Mind
+10x Theft of Vitae
+
+Event (1)
+1x Scourge of the Enochians

--- a/decks/10730.txt
+++ b/decks/10730.txt
@@ -3,7 +3,7 @@ Columbus (OH), USA
 June 22nd, 2023
 2R+F
 29 players
-Norman Brown
+Norm Brown
 www.vekn.net/event-calendar/event/10730
 
 -- 2GW6 + 3vp in the final

--- a/decks/10731.txt
+++ b/decks/10731.txt
@@ -1,0 +1,71 @@
+Origins - Thursday 2
+Columbus (OH), USA
+June 22nd, 2023
+2R+F
+30 players
+Kelly Schultz
+www.vekn.net/event-calendar/event/10731
+
+Deck Name: Adona de Bleedzooka
+
+Crypt (12 cards, min=12 max=44 avg=7)
+5x Adana de Sforza 11 CEL OBF POT PRE PRO aus inner circle Brujah:4
+2x Leo Washington 2 cel pro Gangrel antitribu:4
+1x Alex Camille 5 PRO cel for obf Gangrel antitribu:5
+1x Axel Von Anders 5 PRE cel obf pot Brujah antitribu:4
+1x Loonar 4 PRE cel Toreador antitribu:4
+1x Reginald Moore 4 PRE primogen Brujah:4
+1x Xendil Charmer 7 CEL PRO SER obf priscus Gangrel antitribu:4
+
+Library (69 cards)
+Master (11; 5 trifle)
+1x Direct Intervention
+1x Dreams of the Sphinx
+1x Metro Underground
+1x Pentex(TM) Subversion
+2x Perfectionist
+1x Vessel
+2x Villein
+1x Wash
+1x Wider View
+
+Action (13)
+5x Enchant Kindred
+1x Entrancement
+5x Flurry of Action
+2x Heart of the City
+
+Ally (1)
+1x Carlton Van Wyk
+
+Equipment (1)
+1x Heart of Nizchetus
+
+Political Action (7)
+1x Anarchist Uprising
+1x Ancient Influence
+1x Ancilla Empowerment
+1x Banishment
+2x Kine Resources Contested
+1x Reins of Power
+
+Action Modifier (24)
+2x Cloak the Gathering
+4x Enkil Cog
+2x Faceless Night
+10x Instantaneous Transformation
+2x Iron Glare
+2x Perfect Paragon
+2x Voter Captivation
+
+Action Modifier/Combat (6)
+3x Form of the Cobra
+1x Rapid Change
+2x Resist Earth's Grasp
+
+Action Modifier/Reaction (1)
+1x Form of the Bat
+
+Combat (5)
+1x Earth Meld
+4x Form of Mist

--- a/decks/10732.txt
+++ b/decks/10732.txt
@@ -1,0 +1,57 @@
+Origins - Friday 1
+Columbus (OH), USA
+June 23rd, 2023
+2R+F
+32 players
+Erik Albenze
+www.vekn.net/event-calendar/event/10732
+
+-- 2GW6.5 + 2.5vp in the final
+
+Deck Name: Banu bleed filth
+Description: Combat early, bleed late
+
+Crypt (12 cards; Capacity min=3 max=7 avg=5.166667)
+==================
+2x Farah Sarroub 7 aus obf CEL THA Assamite:6
+3x Kassandra Tassaki 6 obf CEL THA Assamite:6
+2x Khadija Al-Kindi 6 CEL OBF THA Assamite:6
+2x Warmaksan 5 cel obf THA Assamite:6
+2x Nayarana 4 cel THA Assamite:6
+1x Bijou 3 cel tha Assamite:6
+
+Library: 90 cards
+
+Master (17 cards)
+==================
+1x Market Square
+4x Priority Contract
+1x Villein
+1x Black Throne, The
+4x Blood Doll
+6x Haqim's Law: Retribution
+
+Action (8 cards)
+==================
+2x Khabar: Glory
+6x Hunter's Mark
+
+Action Modifier/Combat (12 cards)
+==================
+6x Resist Earth's Grasp
+6x Swallowed by the Night
+
+Combat (39 cards)
+==================
+4x Flash
+4x Pursuit
+7x Quickness
+3x Rego Motum
+2x Walk of Flame
+14x Hunger of Marduk
+5x Blur
+
+Reaction (14 cards)
+==================
+4x On the Qui Vive
+10x Second Tradition: Domain

--- a/decks/10733.txt
+++ b/decks/10733.txt
@@ -1,0 +1,123 @@
+Origins - Friday 2
+Columbus (OH), USA
+June 23rd, 2023
+2R+F
+32 players
+Karl Schaefer
+www.vekn.net/event-calendar/event/10733
+
+-- 2GW7 + 2 vps in the final, won on seeding
+
+Deck Name: Death Star (Setite Version)
+Description: Another of my Death Star variants based on Matt Morgan's design.
+
+The deck behaved differently in each game, but did exactly what I needed each time.
+Game 1 saw early Waters and a fast RevCo. Being in a 4-player with weenie DEM cross-
+table, I had no pressure, which allowed me to setup. Once my predator was ousted, I was
+able to oust my prey with a RevCo and call a Con Boon. I had enough pool to withstand
+the onslaught and my other RevCo for the game win. Game 2 was much different. I had a
+votey prey and had to manage that carefully. He must have felt confident, since I was
+offering little pressure other than bleeds for 1. He dropped to 9 pool and I had a Reckless
+Ag and Eat the Rich for an oust. The following turn I offered a heads-up deal with my
+cross-table for his single vote and ousted his predator while damaging his prey. I allowed
+him to oust his prey without interference and proceeded to oust him the turn after. The
+deal wasn't necessary given that my predator lacked any vote cards to sway the outcome
+of the vote, but it was the safest move.
+
+Bill: weenie DEM 1 VP ->
+Brad: vote something (ousted too fast to know) 0 VP ->
+Norm: g6 Nos w/Protected District 0 VP ->
+Me: 2 VP ->
+Kelly: Malk 2020 2 VP
+
+As first seed, I decided to sit as predator to the doubled-up bleed decks. I hoped that Bill
+would take one and then be ousted, giving me the ability to win by being the last-man
+standing. Things almost didn't go as planned. Bill blew Brad off the table in 17 minutes.
+Norm proved harder to oust with his reduction and I called a Con Boon backwards to help him,
+wanting it to pass by only 2, so I could gain pool, but not blood, as Qufur had self-
+Tempted. That 2 pool proved to be the difference. Bill missed his second oust by 2 pool,
+but Kelly was faster than I had expected. He bled through both Bill and Norm in a single
+turn. The Reckless Ag I had been holding was now useless. Fortunately, I had just drawn
+my first master of the game, The Barrens, and discarded that Reckless. I saw my KRC
+voted down early and never called another damaging vote. I was basically a horde bleed
+deck. At 20 pool going into the heads up and Kelly was at 22. I bleed a bunch and made
+Saatet-Ta, who immediately boosted the next bleed. I see both Spying Missions, which I
+uses on Qufur and Count Ormonde. Kelly bleeds me down to 9, stymied somewhat by my
+desire to not block. I fire off more bleeds the next turn and finish with a Con Boon to end
+at 16. He gets me down to 5, but had less pool than I have minions, so game over. A
+Tempted Waters with 1 blood and Qufur with 1 blood gave me free extra actions for
+moving through the deck, like calling Con Boon, etc. I was lucky to see all of my Boons,
+which made up for not seeing my first master until the heads-up.
+
+CrimethInc. was great today. Saw it in round 1 and the final and was able to get it into
+play both times. The extra unlocks even for a pool were well worth it when I needed them.
+It's worth the card slot, being an easy discard or a powerful effect. On top of that, self-
+Temptations, and Firebrands, this deck can make lots of actions. Knowing what to do
+with those actions is critical.
+
+
+Crypt (12 cards, min=4 max=25 avg=3.67)
+1x Qufur am-Heru 7 OBF PRE SER cel tha Ministry:2
+1x Ezekiel, Lord of Montreal 6 PRE SER obf pot Ministry:3
+1x Hesha Ruhadze 6 SER ani obf pre Ministry:2
+1x Samat Ramal-Ra, Archon 6 OBF pre ser tha Ministry:2
+1x Count Ormonde 5 OBF dom pre ser Ministry:2
+1x Sir Marriot D'Urban 5 PRE aus obf ser Ministry:2
+1x Elizabeth Dimitros 4 SER obf Ministry:3
+5x Anarch Convert 1 Caitiff:ANY
+
+Library (78 cards)
+Master (16; 4 trifle)
+1x Anarch Railroad
+1x Archon Investigation
+1x Barrens, The
+2x Blood Doll
+1x Coven, The
+1x Fear of Mekhet
+1x Ferraille
+1x Garibaldi-Meucci Museum
+3x Obfuscate
+1x Opium Den
+3x Villein
+
+Action (19)
+2x Entrancement
+1x Fee Stake: Boston
+1x Fee Stake: Corte
+1x Fee Stake: Los Angeles
+1x Fee Stake: New York
+1x Fee Stake: Perth
+1x Fee Stake: Seattle
+4x Temptation
+7x Waters of Duat
+
+Ally (1)
+1x Saatet-ta
+
+Political Action (15)
+4x Consanguineous Boon
+1x Domain Challenge
+2x Eat the Rich
+1x Exclusion Principle
+2x Firebrand
+1x Kine Resources Contested
+2x Reckless Agitation
+2x Revolutionary Council
+
+Action Modifier (23)
+2x Bewitching Oration
+1x CrimethInc.
+2x Cryptic Rider
+3x Elder Impersonation
+3x Faceless Night
+2x Lost in Crowds
+2x Memory Rift
+3x Perfect Paragon
+2x Spying Mission
+3x Voter Captivation
+
+Action Modifier/Combat (2)
+2x Swallowed by the Night
+
+Event (2)
+2x Uncoiling, The

--- a/decks/10734.txt
+++ b/decks/10734.txt
@@ -1,0 +1,111 @@
+Origins - Sunday
+Columbus (OH), USA
+June 25th, 2023
+2R+F
+27 players
+Karl Schaefer
+www.vekn.net/event-calendar/event/10734
+
+-- 2GW6 + 3 vps in the final
+
+Deck Name: Shambling into the Void v2
+Description: Shambling Hordes and Emerald Legionnaires
+Some changes from the last time that I won with this deck. Darby Keeney provided some
+comments for more of a mix in masters and in "stealth." The new version flows just as
+well, removing the unnecessary Heart of Nizchetus (the deck is so small it's not required)
+and the excess Dreams for focus on more survivability. Charisma is free Legionnaires and
+with Perfectionist effectively free Hordes. That's powerful. Mylan was the workhorse
+today, allowing me to recruit both a Horde and a Legionnaire in the same round twice and
+bleeding to setup the oust in an early round.
+
+I was second seed, so did not have final choice. I decided to stack the vote decks in
+hopes that would cause contention and sit as Mark's prey because his deck was a slow-
+building one.
+
+Me: 3 VP ->
+Elan: g1/2 Nos with Fortitude 1 VP ->
+Kelly: Capuchin wall 0 VP ->
+Norm: g6 Brujah toolbox 1 VP ->
+Mark: Black Hand swarm 0VP
+
+Instead of going directly for Angelique, which is my usual strategy, I brought Pearl up with
+my first full set of transfers. I had Carlton in hand and wanted him early to help block
+Reunion Kamuts and decrease Mark's speed. While it was the right move, it proved
+unnecessary as Norm wanted to block all of Mark's actions. I allowed it and Mark was
+severely hampered. Norm passed a Poison-Pilled, Reckless Ag to do 5 pool damage to
+his prey and was dropping Anarch Revolts in play. A Monkey Wrench finally got Mark,
+leaving us in a 4-player game with Kelly at 5 pool.
+
+Kelly attempts to make an Anarch, which gets blocked, leaving him susceptible to the
+Revolts on his next turn. My prey is also taking Revolt damage, but I had managed to
+make Angelique an Anarch (thank you Pentex); nothing like putting all your eggs in one
+basket. Kelly gets ousted.
+
+The 3-player devolves quickly as I have Hordes rush a Famed Lucretia, ousting with
+Fame- and Revolt-damage.
+
+In the heads-up, Norm's vampires are all two blood and less. I send Hordes to rush them.
+Over two turns, I manage to dunk all of his vampires. I end my turn and let his own
+Revolts oust him.
+
+This is a deck that likes to hard-recruit Legionnaires, I expect to get a lot out of them
+because the Hordes can protect them. In game 1, when I had been in torpor most of the
+game, I recycled 3. In game 2, I recycled 2. I only recycled 1 on the finals, but held onto
+both of them the entire game.
+
+Crypt (13 cards, min=15 max=36 avg=6.46)
+5x Angelique 9 AUS FOR NEC SER THA Harbinger of Skulls:6
+2x Hecate 6 AUS FOR NEC Harbinger of Skulls:5
+2x La Viuda Blanca 6 AUS NEC for obf Harbinger of Skulls:6
+1x America Johnson 4 AUS vic Tzimisce:5
+1x Pearl 4 AUS obf Malkavian antitribu:5
+1x Tyler McGill 4 AUS pre Toreador:5
+1x Veejay Vinod 3 AUS Nagaraja:6
+
+Library (73 cards)
+Master (15; 3 trifle)
+1x Anarch Troublemaker
+2x Blood Doll
+1x Charisma
+1x Direct Intervention
+2x Dreams of the Sphinx
+1x Fame
+1x Mob Connections
+1x Pentex(TM) Subversion
+2x Perfectionist
+2x Villein
+1x Wider View
+
+Ally (20)
+1x Carlton Van Wyk
+7x Emerald Legionnaire
+1x Mylan Horseed
+11x Shambling Hordes
+
+Action Modifier (8)
+2x Acheron Vortex
+4x Call of the Hungry Dead
+2x Trochomancy
+
+Action Modifier/Combat (3)
+3x Breath of Thanatos
+
+Action Modifier/Reaction (4)
+4x Spectral Divination
+
+Reaction (14)
+3x Eyes of Argus
+2x Funeral Wake
+3x My Enemy's Enemy
+3x On the Qui Vive
+3x Telepathic Misdirection
+
+Combat (5)
+2x Fake Out
+2x Target Vitals
+1x Trap
+
+Event (4)
+1x Dragonbound
+1x FBI Special Affairs Division
+2x Unmasking, The

--- a/decks/10736.txt
+++ b/decks/10736.txt
@@ -1,0 +1,67 @@
+Command Performance: Columbus
+Columbus (OH), USA
+June 19th, 2023
+2R+F
+24 players
+Erik Albenze
+www.vekn.net/event-calendar/event/10736
+
+-- 2GW6 + 3vp in the final
+
+Deck Name: Uncreative Brujah combat
+Description: Combat early, combat late
+
+Crypt (12 cards; Capacity min=3 max=8 avg=5.833333)
+==================
+2x Theo Bell 8 aus dom CEL POT PRE Brujah:6
+3x Aline Gadeke 7 cel POT PRE Brujah:6
+1x Chun Hei 7 CEL POT PRE Brujah:6
+1x Valeriya Zinovieva 7 cel pre pro POT Brujah:6
+2x Atiena 6 pot pre obf CEL Brujah:6
+2x Elen Kamjian 4 CEL POT Brujah:6
+1x Ariane 3 cel pot pre Brujah:5
+
+Library: 90 cards
+
+Master (14 cards)
+==================
+1x Fame
+1x Anarch Free Press, The
+1x Fragment of the Book of Nod
+2x Haven Uncovered
+1x Powerbase: Montreal
+1x Rumor Mill, Tabloid Newspaper, The
+1x Tension in the Ranks
+1x Warzone Hunting Ground
+4x Blood Doll
+1x Carfax Abbey
+
+Action (16 cards)
+==================
+8x Enchant Kindred
+8x Line Brawl
+
+Action Modifier (3 cards)
+==================
+3x Monkey Wrench
+
+Combat (43 cards)
+==================
+2x Flash
+7x Immortal Grapple
+6x Pursuit
+6x Quickness
+6x Taste of Vitae
+8x Torn Signpost
+3x Roundhouse
+2x Blur
+3x Dust Up
+
+Ally (2 cards)
+==================
+2x 47th Street Royals
+
+Reaction (12 cards)
+==================
+4x Bait and Switch
+8x Organized Resistance

--- a/decks/norm98.txt
+++ b/decks/norm98.txt
@@ -1,7 +1,7 @@
 Anarch Revolt
 New Orleans (LA), USA
 December 12th 1998
-Norman Brown, Jr.
+Norm Brown
 
 Deck Name: Oblige Noblisse
 

--- a/decks/normbsl.txt
+++ b/decks/normbsl.txt
@@ -1,7 +1,7 @@
 Blood Siege
 Lafayette (LA), USA
 March 10th 2001
-Norman S. Brown Jr.
+Norm Brown
 https://groups.google.com/g/rec.games.trading-cards.jyhad/c/5SRTsuKd9Yc
 
 Deck Name: Who sez guns don't win?


### PR DESCRIPTION
The NAC is still missing because the Archon has not been approved.

Not sure if it's necessary to know, but the following HoF players added wins:
Mark Loughman
Darby Keeney
Kelly Schultz
Karl Schaefer

Updated Norm Brown's wins to all use the same name (the name on his VEKN ID), so that he can HoF on his next win.