### PR TITLE
Add 9 TWD deck(s) — 2026-04-13

### DIFF
--- a/decks/12012.txt
+++ b/decks/12012.txt
@@ -1,0 +1,54 @@
+Fee Stake: Florence
+Florence, Italy
+February 1st 2025
+2R+F
+38 players
+Luca Turicchi
+https://www.vekn.net/event-calendar/event/12012
+
+Deck Name: No, Tu No!
+Created by: NekrÃ³s
+
+Crypt (12 cards, min=21 max=32 avg=6.58)
+----------------------------------------
+2x Abaddon                          8 cel pot AUS DOM FOR              Salubri:7
+2x Seraphina                        8 cel tha AUS DOM FOR              Salubri:7
+2x Ilonka                           7 tha AUS DOM FOR                  Salubri:7
+2x Aniel                            6 for AUS DOM                      Salubri:7
+2x Malachi                          6 AUS DOM FOR                      Salubri:7
+1x Opikun                           5 aus dom FOR                      Salubri:7
+1x Yael                             4 aus dom for                      Salubri:7
+
+Library (70 cards)
+------------------
+Master (10)
+1x Anarch Troublemaker
+1x Bleeding the Vine
+1x Blind Spot
+1x Coven, The
+1x Dark Influences
+1x Dreams of the Sphinx
+1x Elder Library
+1x Giant's Blood
+1x Misdirection
+1x Wider View
+
+Action (12)
+12x Feast of the Soul's Secrets
+
+Action Modifier (38)
+8x Conditioning
+1x Daring the Dawn
+8x Forced Confessional
+2x Foreshadowing Destruction
+8x Seduction
+3x Sleeping Mind, The
+8x Unleashing the Bestial Soul
+
+Reaction (9)
+5x Deflection
+3x On the Qui Vive
+1x Redirection
+
+Event (1)
+1x Bitter and Sweet Story, The

--- a/decks/12655.txt
+++ b/decks/12655.txt
@@ -1,0 +1,65 @@
+Iubilaeum Sabbaticum
+Roma, Italy
+October 12th 2025
+2R+F
+13 players
+Diego Pignalosa
+https://www.vekn.net/event-calendar/event/12655
+
+Deck Name: Ian Wall
+Created by: Nanogoloso
+
+Crypt (12 cards, min=20 max=37 avg=7.17)
+----------------------------------------
+1x Karl Schrekt                    10 AUS DOM FOR PRE THA   2 votes    Tremere:6
+4x Ian Carfax                       9 for pro AUS DOM THA   Justicar   Tremere:7
+2x Ayelech                          7 AUS DOM THA           Prince     Tremere:6
+1x Inês Tristão                     6 aus dom pre THA       Prince     Tremere:6
+1x Trevon Parker                    6 AUS DOM THA                      Tremere:6
+1x Chrysanthemum                    5 dom AUS THA           Primogen   Tremere:6
+1x Patrik Söderberg                 5 dom for tha AUS                  Tremere:6
+1x Ayse Dhanial                     4 aus dom tha                      Tremere:6
+
+Library (86 cards)
+------------------
+Master (17)
+1x Academic Hunting Ground
+1x Arcane Library
+1x Chantry
+1x Direct Intervention
+1x Life Boon
+1x Powerbase: Montreal
+2x Rack, The
+3x Smiling Jack, The Anarch
+5x Vessel
+1x Wasserschloss Anif, Austria
+
+Action (5)
+5x Magic of the Smith
+
+Equipment (10)
+1x .44 Magnum
+1x Ankara Citadel, Turkey, The
+1x Bowl of Convergence
+2x Heart of Nizchetus
+1x Ivory Bow
+1x Kevlar Vest
+2x Sniper Rifle
+1x Sport Bike
+
+Action Modifier (3)
+3x Conditioning
+
+Reaction (45)
+7x Deflection
+6x Eagle's Sight
+4x Enhanced Senses
+10x Eyes of Argus
+2x My Enemy's Enemy
+3x On the Qui Vive
+6x Second Tradition: Domain
+7x Telepathic Misdirection
+
+Combat (6)
+2x Rego Motum
+4x Theft of Vitae

--- a/decks/12764.txt
+++ b/decks/12764.txt
@@ -1,0 +1,75 @@
+Lithuanian National Championship 2026
+Vilnius, Lithuania
+February 28th 2026
+3R+F
+42 players
+Povilas Zinkevičius
+https://www.vekn.net/event-calendar/event/12764
+
+Deck Name: IT’S A F***ING TOOLBOX
+Created by: Gildor
+
+Crypt (12 cards, min=19 max=36 avg=7.25)
+----------------------------------------
+5x Guillaume Giovanni               9 obt CEL DOM NEC POT              Giovanni:4
+2x Baldesar Rossellini              8 aus for nec DOM POT              Giovanni:4
+1x Don Michael Antonio Giovanni     7 DOM NEC POT           2 votes    Giovanni:4
+1x Accorri Giovanni                 6 ani nec DOM POT                  Giovanni:5
+1x Donatello Giovanni               5 aus pot pre DOM                  Giovanni:4
+1x Gianmaria Giovanni               5 dom nec obt POT                  Giovanni:5
+1x Almodo Giovanni                  3 dom pot                          Giovanni:4
+
+Library (90 cards)
+------------------
+Master (20)
+3x British Museum, London, The
+1x Carver's Meat Packing and Storage
+1x Centralized Background Check
+1x Direct Intervention
+1x Elder Library
+1x Filchware's Pawn Shop
+1x Information Highway
+1x Metro Underground
+1x Monastery of Shadows
+1x Morgue Hunting Ground
+1x Powerbase: Cape Verde
+1x Secure Haven
+2x Vessel
+4x Villein
+
+Action (18)
+5x Bum's Rush
+1x Far Mastery
+9x Govern the Unaligned
+1x Graverobbing
+2x Sudario Refraction
+
+Ally (3)
+1x Gianna di Canneto
+1x Giulia Giovanni Abruzzina
+1x Mylan Horseed
+
+Equipment (10)
+5x Flak Jacket
+1x Gran Madre di Dio, Italy
+2x Kevlar Vest
+1x Palatial Estate
+1x Ruins of Villers Abbey, Belgium
+
+Reaction (8)
+6x Deflection
+1x Delaying Tactics
+1x Redirection
+
+Combat (30)
+2x Earthshock
+6x Immortal Grapple
+2x Pursuit
+6x Roundhouse
+1x Slam
+4x Spiritual Guidance
+4x Taste of Vitae
+5x Torn Signpost
+
+Event (1)
+1x NRA PAC

--- a/decks/12872.txt
+++ b/decks/12872.txt
@@ -1,0 +1,62 @@
+Kiss of Cathari
+Online
+December 21st 2025
+2R+F
+15 players
+Lech Ivanov
+https://www.vekn.net/event-calendar/event/12872
+
+Deck Name: New path of emerald legionnaire
+
+Crypt (12 cards, min=22 max=40 avg=7.5)
+----------------------------------------
+4x Erlik                           10 AUS CEL FOR NEC THN              Harbinger of Skulls:3
+3x Babalawo Alafin                  7 ani AUS FOR NEC                  Harbinger of Skulls:4
+1x Erebus                           7 dem AUS FOR NEC                  Harbinger of Skulls:3
+1x Mina Grotius                     6 cel FOR NEC                      Harbinger of Skulls:3
+1x Zygodat                          6 pot AUS NEC                      Harbinger of Skulls:4
+1x Nicomedes                        5 aus for nec vic                  Harbinger of Skulls:4
+1x Solomon Batanea                  5 nec AUS FOR                      Harbinger of Skulls:4
+
+Library (90 cards)
+------------------
+Master (16)
+1x Anarch Troublemaker
+1x Archon Investigation
+1x Charisma
+1x Coven, The
+1x Direct Intervention
+1x Giant's Blood
+3x Liquidation
+1x Not to Be
+5x Villein
+1x Wider View
+
+Action (16)
+12x Disciple of Lazarus
+4x Soul Feasting
+
+Ally (10)
+10x Emerald Legionnaire
+
+Action Modifier (11)
+3x Call of the Hungry Dead
+8x Freak Drive
+
+Action Modifier/Combat (4)
+4x Breath of Thanatos
+
+Reaction (20)
+4x Delaying Tactics
+3x Eyes of Argus
+4x My Enemy's Enemy
+3x On the Qui Vive
+6x Telepathic Misdirection
+
+Combat (9)
+9x Spiritual Intervention
+
+Event (4)
+1x FBI Special Affairs Division
+1x Scourge of the Enochians
+2x Unmasking, The

--- a/decks/12969.txt
+++ b/decks/12969.txt
@@ -1,0 +1,55 @@
+R&D Paris
+Paris, France
+January 25th 2026
+3R+F
+13 players
+Édouard Menneson
+https://www.vekn.net/event-calendar/event/12969
+
+Deck Name: Guns and shit (mostly guns)
+Created by: Rhazoo
+
+Crypt (12 cards, min=18 max=30 avg=6.17)
+----------------------------------------
+2x Saku Pihlajamäki                 8 for pro CEL POT PRE   Baron      Brujah:6
+2x Aline Gädeke                     7 cel POT PRE           Baron      Brujah:6
+2x Valeriya Zinovieva               7 cel pre pro POT       Baron      Brujah:6
+2x Atiena                           6 obf pot pre CEL       Baron      Brujah:6
+2x Leumeah                          6 cel for pot PRE       Baron      Brujah:6
+1x Anita Wainwright                 3 cel pre                          Brujah:6
+1x Laura Goldman                    3 cel pre                          Brujah:5
+
+Library (80 cards)
+------------------
+Master (18)
+1x Anarch Free Press, The
+1x Carfax Abbey
+1x Club Illusion
+1x Direct Intervention
+1x Dreams of the Sphinx
+1x Fame
+1x Garibaldi-Meucci Museum
+1x New Carthage
+1x Papillon
+1x Powerbase: Los Angeles
+1x Powerbase: Montreal
+7x Villein
+
+Action (6)
+5x Line Brawl
+1x Open War
+
+Equipment (8)
+7x .44 Magnum
+1x Heart of Nizchetus
+
+Reaction (21)
+7x Bait and Switch
+14x Organized Resistance
+
+Combat (27)
+4x Bollix
+6x Concealed Weapon
+10x Diversion
+4x Hell-for-Leather
+3x Taste of Vitae

--- a/decks/13093.txt
+++ b/decks/13093.txt
@@ -1,0 +1,66 @@
+Path of Elysian Choruses
+Stockholm, Sweden
+March 15th 2026
+3R+F
+15 players
+Ivan Marin-Rivas
+https://www.vekn.net/event-calendar/event/13093
+
+Deck Name: Ickypicky
+
+Crypt (12 cards, min=23 max=34 avg=7.17)
+----------------------------------------
+2x Gnaeus Aemilius Augustinus       9 tha DOM OBL POT PRO   Prince     Lasombra:6
+2x María del Toro                   7 DOM OBL POT           Prince     Lasombra:6
+2x Yewon Ong                        8 for DOM OBL POT       Prince     Lasombra:6
+1x Aintzane Arriaga                 6 DOM OBL POT                      Lasombra:6
+1x Azucena                          5 pot DOM OBL                      Lasombra:6
+1x Dafina Hanganu                   8 for DOM OBL POT       Prince     Lasombra:6
+1x Kamaluddin                       6 for pot DOM OBL       Primogen   Lasombra:6
+1x Rasha Tarabzouni                 6 obl pre DOM POT       Bishop     Lasombra:6
+1x Rinaldo Albizzi                  7 pre DOM OBL POT       Primogen   Lasombra:6
+
+Library (84 cards)
+------------------
+Master (13)
+4x Cavalier
+1x Coven, The
+1x Elysian Fields
+1x Giant's Blood
+1x Jake Washington
+1x Line, The
+1x Pentex(TM) Subversion
+1x Power Structure
+2x Wider View
+
+Action (11)
+8x Govern the Unaligned
+1x Scouting Mission
+2x Shroud of Decay
+
+Political Action (9)
+3x Camarilla's Iron Fist
+6x Parity Shift
+
+Ally (10)
+10x Spectral Servitor
+
+Action Modifier (25)
+2x Amici Noctis
+2x Bonding
+4x Conditioning
+2x Foreshadowing Destruction
+3x Shadow Cast
+4x Shadow Cloak
+3x Stygian Shroud
+5x Where the Veil Thins
+
+Action Modifier/Reaction (2)
+2x Ominous Chorus
+
+Reaction (10)
+6x Deflection
+4x Shadow Sentinel
+
+Combat (4)
+4x Pass Through Shadow

--- a/decks/13119.txt
+++ b/decks/13119.txt
@@ -1,0 +1,63 @@
+Liga Powerbase JF 2026 Março
+Juiz de Fora, Brasil
+March 12th 2026
+2R+F
+15 players
+Guilherme Machado (
+https://www.vekn.net/event-calendar/event/13119
+
+Deck Name: Salubri Rush
+
+Crypt (12 cards, min=23 max=31 avg=6.75)
+----------------------------------------
+3x Abaddon                          8 cel pot AUS DOM FOR              Salubri:7
+3x Barachiel                        7 ani AUS DOM FOR                  Salubri:7
+1x Ilonka                           7 tha AUS DOM FOR                  Salubri:7
+2x Malachi                          6 AUS DOM FOR                      Salubri:7
+1x Aniel                            6 for AUS DOM                      Salubri:7
+1x Sakhar                           6 dom AUS FOR                      Salubri:7
+1x Opikun                           5 aus dom FOR                      Salubri:7
+
+Library (90 cards)
+------------------
+Master (14)
+1x Depravity
+1x Direct Intervention
+1x Fame
+1x KRCG News Radio
+1x Meditative Grove
+1x Mob Connections
+1x Powerbase: Montreal
+1x Rack, The
+1x Rötschreck
+2x Saulot's Avenging Fist
+1x Sight Beyond Sight
+2x Vessel
+
+Action (11)
+5x Feast of the Soul's Secrets
+6x Hunting the Beast
+
+Equipment (9)
+1x Bowl of Convergence
+1x Codex of the Edenic Groundskeepers
+1x Ivory Bow
+3x Righteous Blade
+1x Sengir Dagger
+2x Sword of the Archangel
+
+Reaction (22)
+4x Deflection
+8x Eyes of Argus
+2x My Enemy's Enemy
+3x On the Qui Vive
+5x Telepathic Misdirection
+
+Combat (34)
+6x Angel's Gift
+6x Anticipation
+2x Hidden Strength
+4x Indomitability
+6x Taste of Vitae
+3x Telepathic Tracking
+7x Tranquility Shield

--- a/decks/13120.txt
+++ b/decks/13120.txt
@@ -1,0 +1,63 @@
+Path of Govern and Conditioning
+Stockholm, Sweden
+April 11th 2026
+3R+F
+17 players
+Alexander Båskman
+https://www.vekn.net/event-calendar/event/13120
+
+Deck Name: Oblivious in the mountains
+
+Crypt (12 cards, min=17 max=31 avg=6.08)
+----------------------------------------
+1x Dafina Hanganu                   8 for DOM OBL POT       Prince     Lasombra:6
+1x Damian                           8 for pre DOM OBL POT   Archbishop Lasombra:6
+1x Yewon Ong                        8 for DOM OBL POT       Prince     Lasombra:6
+2x Parijat, the Dark Oracle         7 AUS DOM FOR OBL                  Hecata:6
+2x Kamaluddin                       6 for pot DOM OBL       Primogen   Lasombra:6
+1x Aintzane Arriaga                 6 DOM OBL POT                      Lasombra:6
+1x Azucena                          5 pot DOM OBL                      Lasombra:6
+1x Zbigniew, Hunter of Mekhet       5 aus dom tha OBL                  Lasombra:6
+1x El Monseñor                      4 dom OBL                          Lasombra:6
+1x Araceli "Celia" Rivera           3 dom obl                          Lasombra:6
+
+Library (76 cards)
+------------------
+Master (12)
+1x Anarch Troublemaker
+3x Coven, The
+1x Direct Intervention
+2x Dreams of the Sphinx
+1x Elysian Fields
+1x Jake Washington
+3x Life in the City
+
+Action (17)
+13x Govern the Unaligned
+4x Shroud of Decay
+
+Ally (4)
+4x Spectral Servitor
+
+Equipment (1)
+1x Heart of Nizchetus
+
+Action Modifier (28)
+3x Bonding
+3x Conditioning
+2x Daring the Dawn
+4x Freak Drive
+5x Shadow Cast
+5x Shadow Cloak
+3x Stygian Shroud
+3x Where the Veil Thins
+
+Reaction (11)
+6x Deflection
+1x Delaying Tactics
+1x On the Qui Vive
+1x Redirection
+2x Shadow Sentinel
+
+Combat (3)
+3x Pass Through Shadow


### PR DESCRIPTION
Automated weekly import of **9** new tournament winning deck(s) scraped from [vekn.net](https://www.vekn.net/forum/event-reports-and-twd).

| Event ID | Event Name | Location | Date | Winner |
| -------- | ---------- | -------- | ---- | ------ |
| 12655 | [Iubilaeum Sabbaticum](https://www.vekn.net/event-calendar/event/12655) | Roma, Italy | 2025-10-12 | Diego Pignalosa |
| 12872 | [Kiss of Cathari](https://www.vekn.net/event-calendar/event/12872) | Online | 2025-12-21 | Lech Ivanov |
| 12969 | [R&D Paris](https://www.vekn.net/event-calendar/event/12969) | Paris, France | 2026-01-25 | Édouard Menneson |
| 12764 | [Lithuanian National Championship 2026](https://www.vekn.net/event-calendar/event/12764) | Vilnius, Lithuania | 2026-02-28 | Povilas Zinkevičius |
| 13093 | [Path of Elysian Choruses](https://www.vekn.net/event-calendar/event/13093) | Stockholm, Sweden | 2026-03-15 | Ivan Marin-Rivas |
| 13119 | [Liga Powerbase JF 2026 Março](https://www.vekn.net/event-calendar/event/13119) | Juiz de Fora, Brasil | 2026-03-12 | Guilherme Machado ( |
| 13120 | [Path of Govern and Conditioning](https://www.vekn.net/event-calendar/event/13120) | Stockholm, Sweden | 2026-04-11 | Alexander Båskman |
| 12012 | [Fee Stake: Florence](https://www.vekn.net/event-calendar/event/12012) | Florence, Italy | 2025-02-01 | Luca Turicchi |
| 12872 | [Kiss of Cathari](https://www.vekn.net/event-calendar/event/12872) | Online | 2025-12-21 | Lech Ivanov |

_Automatically submitted by [vtes-twd-scraper](https://github.com/Spigushe/twd_scrapper)._