### PR TITLE
Add 4 TWD deck(s) — 2026-05-18

### DIFF
--- a/decks/12012.txt
+++ b/decks/12012.txt
@@ -1,0 +1,54 @@
+Fee Stake: Florence
+Florence, Italy
+February 1st 2025
+2R+F
+38 players
+Luca Turicchi
+https://www.vekn.net/event-calendar/event/12012
+
+Deck Name: No, Tu No!
+Created by: NekrÃ³s
+
+Crypt (12 cards, min=21 max=32 avg=6.58)
+----------------------------------------
+2x Abaddon                          8 cel pot AUS DOM FOR              Salubri:7
+2x Seraphina                        8 cel tha AUS DOM FOR              Salubri:7
+2x Ilonka                           7 tha AUS DOM FOR                  Salubri:7
+2x Aniel                            6 for AUS DOM                      Salubri:7
+2x Malachi                          6 AUS DOM FOR                      Salubri:7
+1x Opikun                           5 aus dom FOR                      Salubri:7
+1x Yael                             4 aus dom for                      Salubri:7
+
+Library (70 cards)
+------------------
+Master (10)
+1x Anarch Troublemaker
+1x Bleeding the Vine
+1x Blind Spot
+1x Coven, The
+1x Dark Influences
+1x Dreams of the Sphinx
+1x Elder Library
+1x Giant's Blood
+1x Misdirection
+1x Wider View
+
+Action (12)
+12x Feast of the Soul's Secrets
+
+Action Modifier (38)
+8x Conditioning
+1x Daring the Dawn
+8x Forced Confessional
+2x Foreshadowing Destruction
+8x Seduction
+3x Sleeping Mind, The
+8x Unleashing the Bestial Soul
+
+Reaction (9)
+5x Deflection
+3x On the Qui Vive
+1x Redirection
+
+Event (1)
+1x Bitter and Sweet Story, The

--- a/decks/13119.txt
+++ b/decks/13119.txt
@@ -1,0 +1,63 @@
+Liga Powerbase JF 2026 Março
+Juiz de Fora, Brasil
+March 12th 2026
+2R+F
+15 players
+Guilherme Machado (
+https://www.vekn.net/event-calendar/event/13119
+
+Deck Name: Salubri Rush
+
+Crypt (12 cards, min=23 max=31 avg=6.75)
+----------------------------------------
+3x Abaddon                          8 cel pot AUS DOM FOR              Salubri:7
+3x Barachiel                        7 ani AUS DOM FOR                  Salubri:7
+1x Ilonka                           7 tha AUS DOM FOR                  Salubri:7
+2x Malachi                          6 AUS DOM FOR                      Salubri:7
+1x Aniel                            6 for AUS DOM                      Salubri:7
+1x Sakhar                           6 dom AUS FOR                      Salubri:7
+1x Opikun                           5 aus dom FOR                      Salubri:7
+
+Library (90 cards)
+------------------
+Master (14)
+1x Depravity
+1x Direct Intervention
+1x Fame
+1x KRCG News Radio
+1x Meditative Grove
+1x Mob Connections
+1x Powerbase: Montreal
+1x Rack, The
+1x Rötschreck
+2x Saulot's Avenging Fist
+1x Sight Beyond Sight
+2x Vessel
+
+Action (11)
+5x Feast of the Soul's Secrets
+6x Hunting the Beast
+
+Equipment (9)
+1x Bowl of Convergence
+1x Codex of the Edenic Groundskeepers
+1x Ivory Bow
+3x Righteous Blade
+1x Sengir Dagger
+2x Sword of the Archangel
+
+Reaction (22)
+4x Deflection
+8x Eyes of Argus
+2x My Enemy's Enemy
+3x On the Qui Vive
+5x Telepathic Misdirection
+
+Combat (34)
+6x Angel's Gift
+6x Anticipation
+2x Hidden Strength
+4x Indomitability
+6x Taste of Vitae
+3x Telepathic Tracking
+7x Tranquility Shield

--- a/decks/13121.txt
+++ b/decks/13121.txt
@@ -1,0 +1,78 @@
+Burst of Solna
+Solna, Sweden
+May 9th 2026
+3R+F
+18 players
+Nina Nilsson
+https://www.vekn.net/event-calendar/event/13121
+
+Deck Name: Its a g-thing
+Created by: Kimbo
+
+Crypt (12 cards, min=17 max=30 avg=5.92)
+----------------------------------------
+1x Keegan                           8 aus cel ANI FOR PRO              Gangrel:6
+1x Ragnar Nordstrom                 8 cel pot ANI FOR PRO              Gangrel:6
+2x Massimiliano                     7 pro ANI FOR           Baron      Gangrel:6
+2x Casey Snyder                     6 ani cel for PRO       Baron      Gangrel:6
+2x Kuyén                            6 ANI PRO               Baron      Gangrel:6
+1x Kamile Paukstys                  5 ani for PRO                      Gangrel:6
+1x Mickey Wheeler                   5 ani cel for pro                  Gangrel:6
+1x Hanna Nokelainen                 4 ani for pro                      Gangrel:6
+1x Indira                           3 PRO                              Gangrel:6
+
+Library (81 cards)
+------------------
+Master (20)
+1x Blood Doll
+2x Carfax Abbey
+2x Club Illusion
+1x Ecoterrorists
+1x Ennoia's Theater
+2x Gangrel Revel
+1x Garibaldi-Meucci Museum
+1x Powerbase: Montreal
+1x Rack, The
+1x Smiling Jack, The Anarch
+3x Vessel
+4x Villein
+
+Action (12)
+1x Army of Rats
+1x Constant Revolution
+1x Gather
+1x Rewilding
+1x Shattering
+7x Thing
+
+Ally (1)
+1x Double Deuce
+
+Equipment (2)
+1x Heart of Nizchetus
+1x Ivory Bow
+
+Retainer (3)
+3x Raven Spy
+
+Action Modifier (2)
+1x Earth Control
+1x Forced March
+
+Action Modifier/Reaction (3)
+3x Form of the Bat
+
+Reaction (21)
+4x Bait and Switch
+5x Deep Ecology
+4x Eyes of the Wild
+6x Organized Resistance
+2x Protection Racket
+
+Combat (17)
+3x Claws of the Dead
+4x Diversion
+3x Donnybrook
+3x Earth Meld
+2x Form of Mist
+2x Hell-for-Leather

--- a/decks/13231.txt
+++ b/decks/13231.txt
@@ -1,0 +1,67 @@
+Fee Stake: Lublin 2026
+Lublin, Poland
+May 16th 2026
+3R+F
+25 players
+Tomasz Pietkiewicz
+https://www.vekn.net/event-calendar/event/13231
+
+Deck Name: Gangrel No Council
+
+Crypt (12 cards, min=14 max=26 avg=5.33)
+----------------------------------------
+2x Massimiliano                     7 pro ANI FOR           Baron      Gangrel:6
+2x Casey Snyder                     6 ani cel for PRO       Baron      Gangrel:6
+2x Kuyén                            6 ANI PRO               Baron      Gangrel:6
+1x André the Manipulator            6 FOR PRO                          Gangrel:5
+1x Martina Srnankova                6 ani FOR PRO                      Gangrel:6
+1x Kamile Paukstys                  5 ani for PRO                      Gangrel:6
+1x Nathan Turner                    4 ani PRO                          Gangrel:6
+1x Indira                           3 PRO                              Gangrel:6
+1x Ruslan Fedorenko                 2 pro                              Gangrel:6
+
+Library (80 cards)
+------------------
+Master (21)
+1x Anarch Free Press, The
+1x Anarch Railroad
+1x Archon Investigation
+1x Backways
+1x Carfax Abbey
+2x Club Illusion
+2x Direct Intervention
+1x Ecoterrorists
+1x Garibaldi-Meucci Museum
+1x Life Boon
+2x Vessel
+5x Villein
+1x Wider View
+1x Zoo Hunting Ground
+
+Action (8)
+8x Thing
+
+Equipment (3)
+1x Heart of Nizchetus
+2x Sniper Rifle
+
+Retainer (4)
+1x Mr. Winthrop
+3x Raven Spy
+
+Action Modifier (1)
+1x Monkey Wrench
+
+Action Modifier/Reaction (4)
+4x Form of the Bat
+
+Reaction (24)
+8x Bait and Switch
+5x Deep Ecology
+9x Organized Resistance
+2x Protection Racket
+
+Combat (15)
+1x Donnybrook
+10x Earth Meld
+4x Form of Mist


### PR DESCRIPTION
Automated weekly import of **4** new tournament winning deck(s) scraped from [vekn.net](https://www.vekn.net/forum/event-reports-and-twd).

| Event ID | Event Name | Location | Date | Winner |
| -------- | ---------- | -------- | ---- | ------ |
| 13119 | [Liga Powerbase JF 2026 Março](https://www.vekn.net/event-calendar/event/13119) | Juiz de Fora, Brasil | 2026-03-12 | Guilherme Machado ( |
| 13121 | [Burst of Solna](https://www.vekn.net/event-calendar/event/13121) | Solna, Sweden | 2026-05-09 | Nina Nilsson |
| 13231 | [Fee Stake: Lublin 2026](https://www.vekn.net/event-calendar/event/13231) | Lublin, Poland | 2026-05-16 | Tomasz Pietkiewicz |
| 12012 | [Fee Stake: Florence](https://www.vekn.net/event-calendar/event/12012) | Florence, Italy | 2025-02-01 | Luca Turicchi |

_Automatically submitted by [vtes-twd-scraper](https://github.com/Spigushe/twd_scrapper)._