### PR TITLE
Update event details in 2015camb.txt: 3R+F

### DIFF
--- a/decks/2015camb.txt
+++ b/decks/2015camb.txt
@@ -1,7 +1,7 @@
 Campeonato Alagoano
 Maceió, Brazil
 September 6th 2015
-4R+F
+3R+F
 12 players
 Fernando Cesar
 https://www.vekn.net/event-calendar/event/8226


### PR DESCRIPTION
Mis-recorded 4R+F, was a 3R+F tournament
Archon even record shows 9GWs over 3 tables = 3 prelim rounds